### PR TITLE
Fix Capital Gains Rate display

### DIFF
--- a/src/components/Individual.js
+++ b/src/components/Individual.js
@@ -1,52 +1,25 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 
 import Wrapper from './ui/Wrapper';
-import { ChartTabs, ChartTab } from './ui/ChartTabs';
 import { KeyFigures, KeyFigure } from './ui/KeyFigures';
 import ReportsAndData from './ui/ReportsAndData';
 import IndividualChart from './charts/IndividualChart';
 
 const TaxBurdenOnLabor = ({ data }) => {
-  const [activeTab, setActiveTab] = useState('tax-burden-on-labor');
   const country = { ...data.countriesCsv };
   const theData = data.taxBurdenOnLaborCsv;
-  const tabOptions = [
-    {
-      name: 'Tax Burden on Labor',
-      id: 'tax-burden-on-labor',
-    },
-    // {
-    //   name: 'Income Tax Map',
-    //   id: 'income-tax-map',
-    // },
-  ];
+
   return (
     <Wrapper>
-      <ChartTabs>
-        {tabOptions.length > 1 &&
-          tabOptions.map(choice => (
-            <ChartTab
-              key={`rank-choice-${choice.id}`}
-              active={activeTab === choice.id}
-            >
-              <button onClick={() => setActiveTab(choice.id)}>
-                {choice.name}
-              </button>
-            </ChartTab>
-          ))}
-      </ChartTabs>
-      {activeTab === 'tax-burden-on-labor' && (
-        <>
-          <IndividualChart
-            title={`How Does${country.article ? ' ' + country.article : ''} ${
-              country.name
-            }'s Tax Burden on Individuals Compare?`}
-            data={theData}
-          />
-        </>
-      )}
+      <IndividualChart
+        title={`How Does${country.article ? ' ' + country.article : ''} ${
+          country.name
+        }'s Tax Burden on Individuals Compare?`}
+        data={theData}
+      />
+
       <KeyFigures>
         <KeyFigure>
           <h3>Share of Revenue from Individual Taxes</h3>
@@ -93,6 +66,7 @@ export const query = graphql`
       Social_Insurance_Taxes
     }
     indexRawDataCsv(ISO_3: { eq: $iso3 }) {
+      year
       capital_gains_rate
     }
   }

--- a/src/components/Individual.js
+++ b/src/components/Individual.js
@@ -31,9 +31,11 @@ const TaxBurdenOnLabor = ({ data }) => {
         </KeyFigure>
         <KeyFigure>
           <h3>Capital Gains Tax Rate</h3>
-          <div>{`${(data.indexRawDataCsv.capital_gains_rate * 100).toPrecision(
-            2
-          )}%`}</div>
+          <div>{`${
+            Math.round(
+              data.allIndexRawDataCsv.nodes[0].capital_gains_rate * 10000
+            ) / 100
+          }%`}</div>
         </KeyFigure>
       </KeyFigures>
       <ReportsAndData
@@ -65,9 +67,14 @@ export const query = graphql`
       Individual_Taxes
       Social_Insurance_Taxes
     }
-    indexRawDataCsv(ISO_3: { eq: $iso3 }) {
-      year
-      capital_gains_rate
+    allIndexRawDataCsv(
+      filter: { ISO_3: { eq: $iso3 } }
+      sort: { year: DESC }
+      limit: 1
+    ) {
+      nodes {
+        capital_gains_rate
+      }
     }
   }
 `;


### PR DESCRIPTION
This PR fixed the display of capital gains rates by modifying the GraphQL query to fetch whichever record from the index raw data matches the given country *and* is the most recent. The previous bug was a result of not fetching the most recent year, and so old data continued to be displayed.

This PR also fixes formatting of the capital gains rate to fix premature rounding, and removes some unused code.